### PR TITLE
ci: Add mkdocs docstring dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,6 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material "mkdocstrings-python"
       - run: mkdocs gh-deploy --force
 


### PR DESCRIPTION
Add dependency so that our Actions runner can generate docs from our docstrings.